### PR TITLE
Revert Deathlink removal

### DIFF
--- a/src/main/java/gg/archipelago/client/ArchipelagoClient.java
+++ b/src/main/java/gg/archipelago/client/ArchipelagoClient.java
@@ -40,6 +40,7 @@ public abstract class ArchipelagoClient {
     private final LocationManager locationManager;
     private final ItemManager itemManager;
     private final EventManager eventManager;
+    private final DeathLink deathLink;
 
     public static final Version protocolVersion = new Version(0, 3, 7);
 
@@ -59,6 +60,7 @@ public abstract class ArchipelagoClient {
         eventManager = new EventManager();
         locationManager = new LocationManager(this);
         itemManager = new ItemManager(this);
+        deathLink = new DeathLink(this);
         archipelagoClient = this;
     }
 


### PR DESCRIPTION
I noticed this was removed in [this commit](https://github.com/ArchipelagoMW/Archipelago.MultiClient.Java/commit/c82fd971c73c199c98cc8668b6ad4f021aad9e57), which was causing an error in the below code, since the `archipelagoClient` field is never assigned.
I'm not sure if this was intentional, but I believe this may be what was breaking the receiving of death links in Minecraft.

https://github.com/ArchipelagoMW/Archipelago.MultiClient.Java/blob/3fd5158c2171276a8ebad58d319eaadecb27a531/src/main/java/gg/archipelago/client/helper/DeathLink.java#L25-L35