### PR TITLE
Add a helper function to get the location ID from an inputted name

### DIFF
--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -109,7 +109,6 @@ public class LocationManager {
                  )
                  .map(game -> game.locationNameToId
                         .get(locationName)
-                 )
-        );
+                 );
     }
 }

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -93,6 +93,11 @@ public class LocationManager {
         this.missingLocations.addAll(missingLocations);
     }
 
+    /*
+    Helper to get the location ID from an inputted location name as a String. Only use this
+    if you know what you're dealing with, and can accept that getting this from the datapackage
+    is not 100% reliable.
+     */
     public long getLocationNameFromID(String locationName){
         return this.client.getDataPackage().getGame(this.client.getGame()).locationNameToId.get(locationName);
     }

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -93,10 +93,13 @@ public class LocationManager {
         this.missingLocations.addAll(missingLocations);
     }
 
-    /*
+    /**
     Helper to get the location ID from an inputted location name as a String. Only use this
     if you know what you're dealing with, and can accept that getting this from the datapackage
     is not 100% reliable.
+
+     @param locationName The name of the location you wish to look up.
+     @return The ID of the location that you have looked up from the datapackage.
      */
     public long getLocationNameFromID(String locationName){
         return this.client.getDataPackage().getGame(this.client.getGame()).locationNameToId.get(locationName);

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -101,7 +101,7 @@ public class LocationManager {
      @param locationName The name of the location you wish to look up.
      @return The ID of the location that you have looked up from the datapackage.
      */
-    public long getLocationNameFromID(String locationName){
+    public Optional<Long> getLocationNameFromID(String locationName){
         return this.client.getDataPackage().getGame(this.client.getGame()).locationNameToId.get(locationName);
     }
 }

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -92,4 +92,8 @@ public class LocationManager {
         this.missingLocations.clear();
         this.missingLocations.addAll(missingLocations);
     }
+
+    public long getLocationNameFromID(String locationName){
+        return this.client.getDataPackage().getGame(this.client.getGame()).locationNameToId.get(locationName);
+    }
 }

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -102,6 +102,12 @@ public class LocationManager {
      @return The ID of the location that you have looked up from the datapackage.
      */
     public Optional<Long> getLocationNameFromID(String locationName){
-        return this.client.getDataPackage().getGame(this.client.getGame()).locationNameToId.get(locationName);
+        return Optional.ofNullable(
+                this.client
+                        .getDataPackage()
+                        .getGame(this.client.getGame())
+                        .locationNameToId
+                        .get(locationName)
+        );
     }
 }

--- a/src/main/java/io/github/archipelagomw/LocationManager.java
+++ b/src/main/java/io/github/archipelagomw/LocationManager.java
@@ -106,8 +106,10 @@ public class LocationManager {
                 this.client
                         .getDataPackage()
                         .getGame(this.client.getGame())
-                        .locationNameToId
+                 )
+                 .map(game -> game.locationNameToId
                         .get(locationName)
+                 )
         );
     }
 }


### PR DESCRIPTION
This PR adds a helper function to abstract getting a location ID from a name if you're making a generic client like https://github.com/benny-dreamly/ArchipelagoMusicClient that can't really bundle the data package of all the clients inside itself. It also adds a docstring that makes it obvious that you should only use this if you understand the implications of it. (I'm not sure if the doctoring is correct, but I copied what I had seen in the past)