### PR TITLE
CI: implement best practices and update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ name: Java CI with Maven
 
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   build:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions: {}
+
 jobs:
   build:
     if: github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
       - name: Build with Gradle
         # This just publishes to the local file system; jreleaser is responsible for uploading to maven central
         run: ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     if: github
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - 'main'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependancy-graph.yml
+++ b/.github/workflows/update-dependancy-graph.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   dependency-graph:
 

--- a/.github/workflows/update-dependancy-graph.yml
+++ b/.github/workflows/update-dependancy-graph.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
       - name: Submit Dependency Snapshot
-        uses: gradle/actions/dependency-submission@v4
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
* use cooldown in dependabot config:
  * this delays opening non-security PRs by 3 days, hopefully skipping any bad updates
  * Actions currently do not support cooldown, but hopefully this will be added in the future.
* put `permissions:` everywhere with the minimal set of actually required permissions:
  * secrets should always be available, I think (if not we'll only see this after merging)
  * checkout and upload-artifact work with empty permissions on public repos
  * required permissions for dependency graph are copied from action documentation
* disable cache for release build - this makes it impossible to poison the cache of release builds
* update actions to latest and pin them
  * the changes look compatible
  * `actions/*` still use the discontinued preview of immutable actions. If immutable actions ever get completely removed, I hope `actions/*` will move to immutable releases (to make tags immutable)
  * the `gradle/*` is third party, so we pin by hash

We should probably make the maven signing/publish conditional at some point so forks can build in CI.